### PR TITLE
Fix compile warnings

### DIFF
--- a/lib/twittex/client.ex
+++ b/lib/twittex/client.ex
@@ -23,7 +23,7 @@ defmodule Twittex.Client do
   """
   @spec search(String.t, Keyword.t) :: {:ok, %{}} | {:error, HTTPoison.Error.t}
   def search(query, options \\ []) do
-    get "/search/tweets.json?" <> URI.encode_query(Dict.merge(%{q: query}, options))
+    get "/search/tweets.json?" <> URI.encode_query(%{q: query} |> Enum.into(options))
   end
 
   @doc """
@@ -32,7 +32,7 @@ defmodule Twittex.Client do
   """
   @spec search!(String.t, Keyword.t) :: %{}
   def search!(query, options \\ []) do
-    get! "/search/tweets.json?" <> URI.encode_query(Dict.merge(%{q: query}, options))
+    get! "/search/tweets.json?" <> URI.encode_query(%{q: query} |> Enum.into(options))
   end
 
   @doc """
@@ -59,7 +59,7 @@ defmodule Twittex.Client do
   """
   @spec user_timeline(String.t, Keyword.t) :: {:ok, %{}} | {:error, HTTPoison.Error.t}
   def user_timeline(screen_name, options \\ []) do
-    get "/statuses/user_timeline.json?" <> URI.encode_query(Dict.merge(%{screen_name: screen_name}, options))
+    get "/statuses/user_timeline.json?" <> URI.encode_query(%{screen_name: screen_name} |> Enum.into(options))
   end
 
   @doc """
@@ -68,7 +68,7 @@ defmodule Twittex.Client do
   """
   @spec user_timeline!(String.t, Keyword.t) :: %{}
   def user_timeline!(screen_name, options \\ []) do
-    get! "/statuses/user_timeline.json?" <> URI.encode_query(Dict.merge(%{screen_name: screen_name}, options))
+    get! "/statuses/user_timeline.json?" <> URI.encode_query(%{screen_name: screen_name} |> Enum.into(options))
   end
 
   @doc """
@@ -127,9 +127,9 @@ defmodule Twittex.Client do
 
     url =
       case query do
-        :user   -> "https://userstream.twitter.com/1.1/user.json?" <> URI.encode_query(Dict.merge(%{delimited: "length"}, options))
-        :sample -> "https://stream.twitter.com/1.1/statuses/sample.json?" <> URI.encode_query(Dict.merge(%{delimited: "length"}, options))
-        _       -> "https://stream.twitter.com/1.1/statuses/filter.json?" <> URI.encode_query(Dict.merge(%{track: query, delimited: "length"}, options))
+        :user   -> "https://userstream.twitter.com/1.1/user.json?" <> URI.encode_query(%{delimited: "length"} |> Enum.into(options))
+        :sample -> "https://stream.twitter.com/1.1/statuses/sample.json?" <> URI.encode_query(%{delimited: "length"} |> Enum.into(options))
+        _       -> "https://stream.twitter.com/1.1/statuses/filter.json?" <> URI.encode_query(%{track: query, delimited: "length"} |> Enum.into(options))
       end
 
     case stage :post, url do

--- a/mix.exs
+++ b/mix.exs
@@ -8,12 +8,12 @@ defmodule Twittex.Mixfile do
      name: "Twittex",
      version: @version,
      elixir: "~> 1.3",
-     package: package,
-     description: description,
+     package: package(),
+     description: description(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     docs: docs,
-     deps: deps]
+     docs: docs(),
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
Hello!

I am very new to Elixir (this is my first pull request for an Elixir project 🎉 ) I just saw the warnings and thought I would take a crack at fixing them.  Let me know if I can doing anything else.

Had some compile warnings today when I brought Twittex into a project I was working on.  Attached are some screenshots of what I was seeing when I would run `iex -S mix`.

**Dict.merge/2 is deprecated:**
![screen shot 2017-03-09 at 2 40 36 pm](https://cloud.githubusercontent.com/assets/413224/23769857/6cbbfb04-04d6-11e7-8eeb-4e7519c2f357.png)

**please use parentheses to remove the ambiguity or change the variable name:**
![screen shot 2017-03-09 at 2 35 04 pm](https://cloud.githubusercontent.com/assets/413224/23769696/d54a4726-04d5-11e7-8d58-ab2af938797d.png)

This pull request corrected the deprecation warnings I was seeing when I fired up `iex`.  Please let me know if I should change the branch that I am merging into or anything.  I forked the project created a branch with my work.

**Edit:** This is with Elixir 1.4.2

Thanks!